### PR TITLE
Added support for _changes feed

### DIFF
--- a/spine-adapter/couch-ajax.coffee
+++ b/spine-adapter/couch-ajax.coffee
@@ -59,7 +59,7 @@ CouchAjax =
       @requests.push(callback)
     else
       @pending = true
-      @request(callback)    
+      @request(callback)
     callback
     
 class Base
@@ -76,7 +76,7 @@ class Base
     CouchAjax.queue(callback)
 
 class Collection extends Base
-  constructor: (@model) -> 
+  constructor: (@model) ->
     
   find: (id, params) ->
     record = new @model(id: id)
@@ -163,6 +163,8 @@ class Singleton extends Base
       else
         data = @model.fromJSON(data)
     
+      data._rev = data._rev || xhr.getResponseHeader( 'X-Couch-Update-NewRev' )
+
       CouchAjax.disable =>
         if data
           # ID change, need to do some shifting
@@ -192,7 +194,7 @@ Include =
     base += encodeURIComponent(@id)
     base
     
-Extend = 
+Extend =
   ajax: -> new Collection(this)
 
   url: ->
@@ -212,7 +214,7 @@ Model.CouchAjax =
   ajaxChange: (record, type, options = {}) ->
     record.ajax()[type](options.ajax, options)
     
-Model.CouchAjax.Methods = 
+Model.CouchAjax.Methods =
   extended: ->
     @extend Extend
     @include Include

--- a/spine-adapter/couch-ajax.coffee
+++ b/spine-adapter/couch-ajax.coffee
@@ -189,7 +189,6 @@ Changes = () ->
   
   q = include_docs: yes
     
-  console.log( "_changes handler entered" )
   appdb.changes q, (err, resp) =>
     # disable updating the already updated database
     Spine.CouchAjax.disable ->
@@ -200,20 +199,15 @@ Changes = () ->
           atts.id = atts._id unless atts.id
           try
             obj = klass.find( atts.id )
-            console.log(" ID #{atts.id} found" )
             if doc.deleted
               obj.destroy()
-              console.log(" ID #{atts.id} destroyed" )
             else
               unless obj._rev is atts._rev
                 obj.updateAttributes( atts )
-                console.log(" ID #{atts.id} updated" )
-                console.log( atts )
           catch e
             klass.create( atts ) unless doc.deleted
-            console.log(" ID #{atts.id} created" )
         else
-          console.log( "changes: can't find subscriber for #{doc.doc._id}" )
+          console.warn( "changes: can't find subscriber for #{doc.doc.modelname}" )
     yes
 
   subscribe: ( classname, klass ) ->

--- a/spine-adapter/updates.coffee
+++ b/spine-adapter/updates.coffee
@@ -1,7 +1,7 @@
 {_} = require("underscore")
 
 exports.spine_adapter_model = (doc, req) ->
-  if req.method is 'POST'    
+  if req.method is 'POST'
     create(doc, req)
   else if req.method is 'PUT'
     update(doc, req)
@@ -32,3 +32,4 @@ destroy = (doc, req) ->
   resp =
     ok: yes
   [doc, resp]
+


### PR DESCRIPTION
This code silently injects "_rev" attribute into every model and subscribes it to the _changes events via a central Changes dispatch object.

"_rev" injection is needed for update support (or else 409) and is a hack, I found no way to officially append to @attributes from the @extend'ee class. Comments welcome.

Potential problem: because spine-adapter uses update handlers, the _rev is missing from the received JSON. I retrieve it from the HTTP response header. Don't know in which version of Couch this header was introduced.
