### PR TITLE
Move `Changes` logic to separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,34 @@ Add `spine-adapter` to your dependencies in `kanso.json` and run `kanso fetch`.
 }
 ```
 
-`require` Spine modules you'll use. `spine/core` is required for any use of Spine. `spine-adapter/couch-ajax` is required to persist your models in couchdb.
+`require` Spine modules you'll use. `spine/core` is required for any use of Spine. `spine-adapter/couch-ajax` is required to persist your models in couchdb. `spine-adapter/couch-changes` is required to handle `_changes` feed.
 
 ```coffeescript
 # Creates the global 'Spine' object
 require("spine/core")
 require("spine-adapter/couch-ajax")
+require("spine-adapter/couch-changes")
 
 class BlogPost extends Spine.Model
   @configure "BlogPost", "title", "body"
 
   # Enables CouchDB storage for instances of this model
   @extend Spine.Model.CouchAjax
+  # Subscribes on _changes feed
+  @extend Spine.Model.CouchChanges()
 ```
+
+You may specify database url and override changes handler by passing options as an argument to CouchChanges
+
+```coffeescript
+class BlogPost extends Spine.Model
+  ...
+  @extend Spine.Model.CouchChanges
+    url:     "/blogs"
+    handler: Spine.Model.CouchChanges.PrivateChanges
+```
+
+Using of PrivateChanges handle will connect to `_changes` feed only when user is authenticated.
 
 To fetch a specific set of records (rather than all records of a type), use the `db` module to retreive a view. Pass the docs from that view to the model's `refresh` method.
 

--- a/spine-adapter/couch-changes.coffee
+++ b/spine-adapter/couch-changes.coffee
@@ -1,0 +1,76 @@
+db       = require "db"
+duality  = require "duality/core"
+session  = require "session"
+
+
+feeds = {} # Cache `_changes` feeds by their url
+
+
+Spine.Model.CouchChanges = (opts = {})->
+  opts.url = opts.url or duality.getDBURL()
+  opts.handler = Spine.Model.CouchChanges.Changes unless opts.handler
+  feeds[opts.url] or feeds[opts.url] =
+    changes: new opts.handler opts
+    extended: ->
+      # need to keep _rev around to support changes feed processing
+      @attributes.push "_rev" unless @attributes[ "_rev" ]
+      @changes.subscribe @className, @
+
+
+Spine.Model.CouchChanges.Changes = class Changes
+  subscribers: {}
+  query: include_docs: yes
+
+  constructor: (options = {})->
+    @url = options.url
+    @startListening()
+
+  subscribe: (classname, klass) =>
+    @subscribers[classname.toLowerCase()] = klass
+
+  startListening: =>
+    db.use(@url).changes @query, @handler()
+
+  # returns handler which you may disable by setting handler.disabled flag `true`
+  handler: -> self = (err, resp) =>
+    if self.disabled then false
+    else if err then false # TODO? @trigger error
+    else
+      @acceptChanges resp?.results
+      true
+
+  acceptChanges: (changes)->
+    return unless changes
+    Spine.CouchAjax.disable =>
+      for doc in changes
+        if modelname = doc.doc?.modelname
+          klass = @subscribers[modelname]
+        unless klass
+          console.warn "changes: can't find subscriber for #{doc.doc.modelname}"
+          continue
+        atts = doc.doc
+        atts.id = atts._id unless atts.id
+        try
+          obj = klass.find atts.id
+          if doc.deleted
+            obj.destroy()
+          else
+            unless obj._rev is atts._rev
+              obj.updateAttributes atts
+        catch e
+          klass.create atts unless doc.deleted
+
+
+# Start listening for _changes only when user is authenticated
+#   and stop listening for changes when he logged out
+Spine.Model.CouchChanges.PrivateChanges = class PrivateChanges extends Changes
+  startListening: =>
+    session.on "change", @authChanged
+
+  authChanged: (userCtx)=>
+    if userCtx.name
+      @currentHandler.disabled = true if @currentHandler
+      @currentHandler = @handler()
+      db.use(@url).changes @query, @currentHandler
+    else
+      @currentHandler.disabled = true if @currentHandler


### PR DESCRIPTION
Hi Nicholas.

I pulled `_changes` feed handler to separate file and made it more agile:
- Changes subscription is optional now (you may or may not extend your model with `.CouchChanges`). That makes your master branch compatible with the version from kanso repository.
- Subscription logic is extendable (see `.CouchChanges.PrivateChanges` as an example)
- You may specify custom database url

If you find this patch reasonable – please accept my pull request, bump the version and push it to kanso repo.

Regards,
Yury
